### PR TITLE
Bump tested to and remove extra contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Email Test's Changelog
 
+## 1.0.3 (January 15, 2022)
+
+* Bump tested to up to 5.8
+
 ## 1.0.2 (March 14, 2021)
 
 * Bump tested to up to 5.7

--- a/email-test.php
+++ b/email-test.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Email Test
  * Description: Test your site's email to make sure emails are being sent.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: SiteAlert
  * Author URI: https://sitealert.io
  * Text Domain: email-test

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Email Test - Check if your emails are being delivered ===
-Contributors: sitealert, fpcorso
+Contributors: sitealert
 Tags: mail, email, test, check
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 5.8
 Stable tag: 1.0.2
 Requires PHP: 5.6
 License: GPLv3
@@ -32,6 +32,9 @@ Would you like to have your site's email tested automatically and regularly? All
 1. Test page
 
 == Changelog ==
+
+= 1.0.3 (January 15, 2022) =
+* Bump tested to up to 5.8
 
 = 1.0.2 (March 14, 2021) =
 * Bump tested to up to 5.7


### PR DESCRIPTION
Was using this plugin on a site and noticed it said it wasn't tested with the latest version. Since it worked fine on my 5.8 site, thought I'd submit a PR and also remove myself as contributor on the main plugin page.